### PR TITLE
Update lxd.patch

### DIFF
--- a/lxd.patch
+++ b/lxd.patch
@@ -443,26 +443,6 @@ index 781fcccf..c6cba67a 100644
    }
  
  }
-diff --git a/images/ubuntu/templates/locals.ubuntu.pkr.hcl b/images/ubuntu/templates/locals.ubuntu.pkr.hcl
-index 469493d3..8b137891 100644
---- a/images/ubuntu/templates/locals.ubuntu.pkr.hcl
-+++ b/images/ubuntu/templates/locals.ubuntu.pkr.hcl
-@@ -1,15 +1 @@
--locals {
--  image_properties_map = {
--      "ubuntu22" = {
--            source_image_marketplace_sku = "canonical:0001-com-ubuntu-server-jammy:22_04-lts"
--            os_disk_size_gb = 75
--      },
--      "ubuntu24" = {
--            source_image_marketplace_sku = "canonical:ubuntu-24_04-lts:server-gen1"
--            os_disk_size_gb = 75
--      }
--  }
- 
--  source_image_marketplace_sku = local.image_properties_map[var.image_os].source_image_marketplace_sku
--  os_disk_size_gb = coalesce(var.os_disk_size_gb, local.image_properties_map[var.image_os].os_disk_size_gb)
--}
 diff --git a/images/ubuntu/templates/source.ubuntu.pkr.hcl b/images/ubuntu/templates/source.ubuntu.pkr.hcl
 index babc3cb5..a0fc7d33 100644
 --- a/images/ubuntu/templates/source.ubuntu.pkr.hcl
@@ -522,8 +502,28 @@ index babc3cb5..a0fc7d33 100644
      }
    }
  }
+diff --git a/images/ubuntu/templates/locals.ubuntu.pkr.hcl b/images/ubuntu/templates/locals.ubuntu.pkr.hcl
+index 0c62430a..e69de29b 100644
+--- a/images/ubuntu/templates/locals.ubuntu.pkr.hcl
++++ b/images/ubuntu/templates/locals.ubuntu.pkr.hcl
+@@ -1,15 +0,0 @@
+-locals {
+-  image_properties_map = {
+-      "ubuntu22" = {
+-            source_image_marketplace_sku = "canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2"
+-            os_disk_size_gb = 75
+-      },
+-      "ubuntu24" = {
+-            source_image_marketplace_sku = "canonical:ubuntu-24_04-lts:server"
+-            os_disk_size_gb = 75
+-      }
+-  }
+-
+-  source_image_marketplace_sku = local.image_properties_map[var.image_os].source_image_marketplace_sku
+-  os_disk_size_gb = coalesce(var.os_disk_size_gb, local.image_properties_map[var.image_os].os_disk_size_gb)
+-}
 diff --git a/images/ubuntu/templates/variable.ubuntu.pkr.hcl b/images/ubuntu/templates/variable.ubuntu.pkr.hcl
-index ef48d309..321e79fa 100644
+index 685c6604..af0b7d72 100644
 --- a/images/ubuntu/templates/variable.ubuntu.pkr.hcl
 +++ b/images/ubuntu/templates/variable.ubuntu.pkr.hcl
 @@ -1,136 +1,3 @@
@@ -661,12 +661,5 @@ index ef48d309..321e79fa 100644
 -}
 -
  // Image related variables
- variable "dockerhub_login" {
+ variable "helper_script_folder" {
    type    = string
-@@ -172,4 +39,4 @@ variable "install_password" {
- variable "install_user" {
-   type    = string
-   default = "installer"
--}
-+}
-\ No newline at end of file


### PR DESCRIPTION
I rebuild this patch to work with the latest version of `acxtions/runner-images`. I did this somewhat blindly, but the changes that were causing the patch to fail were in areas of the code that the patch was removing. After making this update the build was successful.

* The patch was deleting the entire contents of this file: `images/ubuntu/templates/locals.ubuntu.pkr.hcl`. The contents of this file changed. I updated the patch to delete the new contents of this file.
* The patch deletes several lines of this this file: `images/ubuntu/templates/variable.ubuntu.pkr.hcl`
   * The lines after the diff changed slightly which caused the patch to fail.

The build seems to work after this update:
https://github.com/Iknite-Space/actions-runner-images-lxd/actions/runs/21195006938

Caveat: I have not yet tested the image that was built.