### PR TITLE
Fix swapoff failure when swapfile does not exist

### DIFF
--- a/.github/workflows/build-jammy.yaml
+++ b/.github/workflows/build-jammy.yaml
@@ -81,7 +81,7 @@
             },
             {
                "name": "Remove swap",
-               "run": "sudo swapoff /mnt/swapfile\nsudo rm -rf /mnt/swapfile\n",
+               "run": "sudo swapoff /mnt/swapfile || true\nsudo rm -rf /mnt/swapfile\n",
                "shell": "bash"
             },
             {

--- a/.github/workflows/build-noble.yaml
+++ b/.github/workflows/build-noble.yaml
@@ -81,7 +81,7 @@
             },
             {
                "name": "Remove swap",
-               "run": "sudo swapoff /mnt/swapfile\nsudo rm -rf /mnt/swapfile\n",
+               "run": "sudo swapoff /mnt/swapfile || true\nsudo rm -rf /mnt/swapfile\n",
                "shell": "bash"
             },
             {

--- a/.github/workflows/lib/step.libsonnet
+++ b/.github/workflows/lib/step.libsonnet
@@ -101,7 +101,7 @@ function(os_version) {
       name: 'Remove swap',
       shell: 'bash',
       run: |||
-        sudo swapoff /mnt/swapfile
+        sudo swapoff /mnt/swapfile || true
         sudo rm -rf /mnt/swapfile
       |||,
     },

--- a/.github/workflows/nightly-jammy.yaml
+++ b/.github/workflows/nightly-jammy.yaml
@@ -81,7 +81,7 @@
             },
             {
                "name": "Remove swap",
-               "run": "sudo swapoff /mnt/swapfile\nsudo rm -rf /mnt/swapfile\n",
+               "run": "sudo swapoff /mnt/swapfile || true\nsudo rm -rf /mnt/swapfile\n",
                "shell": "bash"
             },
             {

--- a/.github/workflows/nightly-noble.yaml
+++ b/.github/workflows/nightly-noble.yaml
@@ -81,7 +81,7 @@
             },
             {
                "name": "Remove swap",
-               "run": "sudo swapoff /mnt/swapfile\nsudo rm -rf /mnt/swapfile\n",
+               "run": "sudo swapoff /mnt/swapfile || true\nsudo rm -rf /mnt/swapfile\n",
                "shell": "bash"
             },
             {


### PR DESCRIPTION
## Summary
- Add `|| true` to `sudo swapoff /mnt/swapfile` to prevent CI failure when the swapfile is absent

## Changes
- `.github/workflows/lib/step.libsonnet`: `sudo swapoff /mnt/swapfile` → `sudo swapoff /mnt/swapfile || true`
- Regenerated all 4 workflow YAML files (`build-noble`, `build-jammy`, `nightly-noble`, `nightly-jammy`)

## Test Plan
- CI should no longer fail with `swapoff: /mnt/swapfile: swapoff failed: No such file or directory` (exit code 4)