### PR TITLE
fix: configure podman to use fuse-overlayfs in LXD containers (jammy)

### DIFF
--- a/lxd.patch
+++ b/lxd.patch
@@ -51,13 +51,17 @@ diff --git a/images/ubuntu/scripts/build/install-container-tools.sh b/images/ubu
 index ac9dcdff..fc23d9fc 100644
 --- a/images/ubuntu/scripts/build/install-container-tools.sh
 +++ b/images/ubuntu/scripts/build/install-container-tools.sh
-@@ -30,4 +30,8 @@ apt-get install ${install_packages[@]}
+@@ -30,4 +30,12 @@ apt-get install ${install_packages[@]}
  mkdir -p /etc/containers
  printf "[registries.search]\nregistries = ['docker.io', 'quay.io']\n" | tee /etc/containers/registries.conf
  
-+if [ -f /etc/containers/storage.conf ]; then
-+    sed -i 's|#mount_program = "/usr/bin/fuse-overlayfs"|mount_program = "/usr/bin/fuse-overlayfs"|g' /etc/containers/storage.conf
-+fi
++cat > /etc/containers/storage.conf << 'EOF'
++[storage]
++driver = "overlay"
++
++[storage.options.overlay]
++mount_program = "/usr/bin/fuse-overlayfs"
++EOF
 +
  invoke_tests "Tools" "Containers"
 diff --git a/images/ubuntu/scripts/build/install-dotnetcore-sdk.sh b/images/ubuntu/scripts/build/install-dotnetcore-sdk.sh


### PR DESCRIPTION
## Summary
- Fix podman networking test failure in Ubuntu 22.04 LXD build caused by `overlay` driver not being supported over extfs

## Changes
- Replace conditional `sed`-based `storage.conf` patching with explicit file creation in `lxd.patch`
- Write a complete `/etc/containers/storage.conf` with:
  - `driver = "overlay"` (explicit driver selection)
  - `mount_program = "/usr/bin/fuse-overlayfs"` (use FUSE-based overlay instead of kernel native)
- This mirrors the approach already used for Docker (`daemon.json` with `fuse-overlayfs`)

## Test Plan
- Build Ubuntu 22.04 LXD image with the updated patch
- Verify `podman network create -d bridge test-net` succeeds
- Verify existing `podman`, `buildah`, `skopeo` tests pass

## Notes
- The previous approach failed because: (1) `storage.conf` might not exist when `sed` runs, (2) uncommenting `mount_program` alone is insufficient without setting `driver = "overlay"`, (3) Ubuntu 22.04's default config format may not match the expected sed pattern